### PR TITLE
Add initial defunct multi-package support for RFC

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -87,13 +87,13 @@ class GlfwConan(ConanFile):
         cmake.definitions["GLFW_BUILD_TESTS"] = False
         cmake.definitions["GLFW_BUILD_DOCS"] = False
 
-        cmake.configure(source_folder=self.sources_folder)
-
         if self.settings.os == "Windows":
-            defs["CMAKE_DEBUG_POSTFIX"] = "d"
+            cmake.definitions["CMAKE_DEBUG_POSTFIX"] = "d"
 
         if self.settings.os != "Windows" and self.options.fPIC:
-            defs["CMAKE_POSITION_INDEPENDENT_CODE:BOOL"] = "on"
+            cmake.definitions["CMAKE_POSITION_INDEPENDENT_CODE:BOOL"] = "on"
+
+        cmake.configure(source_folder=self.sources_folder)
 
         if cmake.is_multi_configuration:
             self.run("cmake --build . --config Debug")

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -9,5 +9,5 @@ conan_basic_setup()
 file(GLOB SOURCE_FILES *.cpp)
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+conan_target_link_libraries(${PROJECT_NAME})
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)


### PR DESCRIPTION
I wanted to create an issue with a question, but since issues seem to be disabled, I'd like to do this using pull requests. This is not meant for immediate merging as it is not completely finished (read, not working), but good enough to have the discussion. 

In order to facilitate switching between release and debug (and other build modes) on Visual Studio without rerunning conan, we (meaning the company I work for) create so called multi-packages. The package for windows will contain both release and debug version at the same time, thus build_type and runtime are removed from settings (see config_options method). In build, the package is just built 2 times and in the packaging, both libraries have to be added. For the runtime, the dynamic multithreaded debug and non-debug are used for debug and release respectively. This is not done for linux and other environments as a build type uses one single build folder. 

Since essentially no package supports this in conan-central, I thought about raising this topic because if accepted, it would prevent us from having to maintain a fork of every recipe we require for our internal software. And I think the ability to switch build modes without rerunning has also benefits outside of what we do... 

So, what do you think? If you are favorable to such a change, I can finish it up and get it into a mergeable state such that it could be included in this recipe. 