### PR TITLE
fix adding libraries as separate list elements.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -123,4 +123,4 @@ class GlfwConan(ConanFile):
                 if self.settings.os == "Macos":
                     self.cpp_info.exelinkflags.append("-framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo")
                 if self.settings.os == "Linux":
-                    self.cpp_info.libs.append("Xrandr Xrender Xi Xinerama Xcursor GL m dl drm Xdamage X11-xcb xcb-glx xcb-dri2 xcb-dri3 xcb-present xcb-sync Xxf86vm Xfixes Xext X11 pthread xcb Xau")
+                    self.cpp_info.libs.extend(['Xrandr', 'Xrender', 'Xi', 'Xinerama', 'Xcursor', 'GL', 'm', 'dl', 'drm', 'Xdamage', 'X11-xcb', 'xcb-glx', 'xcb-dri2', 'xcb-dri3', 'xcb-present', 'xcb-sync', 'Xxf86vm', 'Xfixes', 'Xext', 'X11', 'pthread', 'xcb', 'Xau'])


### PR DESCRIPTION
Library names should be added as separate list elements. With the old code the Premake generator generated the library list which was missing commas, because it regarded a single entry as a single string:
```lua
conan_libs_glfw = {"glfw3", "Xrandr Xrender Xi Xinerama Xcursor GL m dl drm Xdamage X11-xcb xcb-glx xcb-dri2 xcb-dri3 xcb-present xcb-sync Xxf86vm Xfixes Xext X11 pthread xcb Xau"}
```
This caused GCC to not find the libraries because Premake only appended `-l` before each element.

With this fix the library list is properly generated:
```lua
conan_libs_glfw = {"glfw3", "Xrandr", "Xrender", "Xi", "Xinerama", "Xcursor", "GL", "m", "dl", "drm", "Xdamage", "X11-xcb", "xcb-glx", "xcb-dri2", "xcb-dri3", "xcb-present", "xcb-sync", "Xxf86vm", "Xfixes", "Xext", "X11", "pthread", "xcb", "Xau"}
```
