### PR TITLE
Add `libxcb:shared=True` and `libx11:shared=True` default options to fix finding the X11 libraries, fix #1197

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ class GlfwConan(ConanFile):
     description = "The GLFW library - Builds on Windows, Linux and Macos/OSX"
     settings = "os", "arch", "build_type", "compiler"
     options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {'shared': False, "fPIC": True}
+    default_options = {'shared': False, "fPIC": True, 'libxcb:shared': True, 'libx11:shared': True }
     license = "Zlib"
     url = "https://github.com/bincrafters/conan-glfw"
     homepage = "https://github.com/glfw/glfw"


### PR DESCRIPTION
This fixes issue bincrafters/community#1197.