### PR TITLE
Support GLFW_VULKAN_STATIC glfw option

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -8,8 +8,8 @@ class GlfwConan(ConanFile):
     version = "3.3.2"
     description = "The GLFW library - Builds on Windows, Linux and Macos/OSX"
     settings = "os", "arch", "build_type", "compiler"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {'shared': False, "fPIC": True, 'libxcb:shared': True, 'libx11:shared': True }
+    options = {"shared": [True, False], "fPIC": [True, False], "vulkanStatic": [True, False]}
+    default_options = {'shared': False, "fPIC": True, 'libxcb:shared': True, 'libx11:shared': True, 'vulkanStatic': False }
     license = "Zlib"
     url = "https://github.com/bincrafters/conan-glfw"
     homepage = "https://github.com/glfw/glfw"
@@ -48,6 +48,8 @@ class GlfwConan(ConanFile):
         cmake.definitions["GLFW_BUILD_EXAMPLES"] = False
         cmake.definitions["GLFW_BUILD_TESTS"] = False
         cmake.definitions["GLFW_BUILD_DOCS"] = False
+        if self.options.vulkanStatic:
+            cmake.definitions["GLFW_VULKAN_STATIC"] = True
         cmake.configure(build_dir=self._build_subfolder)
         return cmake
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ class GlfwConan(ConanFile):
     description = "The GLFW library - Builds on Windows, Linux and Macos/OSX"
     settings = "os", "arch", "build_type", "compiler"
     options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {'shared': False, "fPIC": True}
+    default_options = {'shared': False, "fPIC": True, 'libxcb:shared': True, 'libx11:shared': True }
     license = "Zlib"
     url = "https://github.com/bincrafters/conan-glfw"
     homepage = "https://github.com/glfw/glfw"


### PR DESCRIPTION
This adds a conan option `vulkanStatic` that sets the CMake option `GLFW_VULKAN_STATIC` for linking the vulkan loader statically to address issue https://github.com/bincrafters/community/issues/1201.